### PR TITLE
File Index crashes when file was removed

### DIFF
--- a/pyfileindex/pyfileindex.py
+++ b/pyfileindex/pyfileindex.py
@@ -209,7 +209,7 @@ class PyFileIndex(object):
                 return []
         except FileNotFoundError:
             return []
-    
+
     def _repr_html_(self):
         """
         Internal visualisation function for iPython notebooks

--- a/pyfileindex/pyfileindex.py
+++ b/pyfileindex/pyfileindex.py
@@ -84,7 +84,9 @@ class PyFileIndex(object):
                 for entry in scandir(path):
                     if entry.is_dir(follow_symlinks=False) and recursive:
                         # yield from self._scandir(path=entry.path, recursive=recursive)  # Python 3.X only
-                        for d in self._scandir(path=entry.path, df=df, recursive=recursive):
+                        for d in self._scandir(
+                            path=entry.path, df=df, recursive=recursive
+                        ):
                             yield d
                         yield self._get_lst_entry(entry=entry)
                     else:

--- a/pyfileindex/pyfileindex.py
+++ b/pyfileindex/pyfileindex.py
@@ -178,7 +178,7 @@ class PyFileIndex(object):
                 return []
         except FileNotFoundError:
             return []
-            
+
     def _get_lst_entry(self, entry):
         """
         Internal function to generate file index entry from scandir DirEntry

--- a/pyfileindex/pyfileindex.py
+++ b/pyfileindex/pyfileindex.py
@@ -67,6 +67,8 @@ class PyFileIndex(object):
         Returns:
             list: list of file entries
         """
+        if not os.path.exists(path):
+            return []
         if df is not None and len(df) > 0:
             for entry in scandir(path):
                 if entry.path not in df.path.values:

--- a/pyfileindex/pyfileindex.py
+++ b/pyfileindex/pyfileindex.py
@@ -157,6 +157,8 @@ class PyFileIndex(object):
         Returns:
             list: file index entry
         """
+        if not os.path.exists(entry):
+            return []
         stat = os.stat(entry)
         isdir = os.path.isdir(entry)
         if not isdir and self._filter_function is not None:
@@ -185,6 +187,8 @@ class PyFileIndex(object):
         Returns:
             list: file index entry
         """
+        if not os.path.exists(entry):
+            return []
         stat = entry.stat()
         isdir = entry.is_dir()
         if not isdir and self._filter_function is not None:


### PR DESCRIPTION
The underlying directory was compressed as part of the output: 
```
File /global/common/software/m3805/conda/lib/python3.9/site-packages/pyfileindex/pyfileindex.py:126, in PyFileIndex.update(self)
    122 def update(self):
    123     """
    124     Update file index
    125     """
--> 126     df_new, files_changed_lst, path_deleted_lst = self._get_changes_quick()
    127     if self._debug:
    128         print("Changes: ", df_new.path.values, files_changed_lst, path_deleted_lst)

File /global/common/software/m3805/conda/lib/python3.9/site-packages/pyfileindex/pyfileindex.py:117, in PyFileIndex._get_changes_quick(self)
    115 else:
    116     files_changed_lst, dir_changed_lst = [], []
--> 117 df_new = self._init_df_lst(
    118     path_lst=dir_changed_lst, df=df_exists, include_root=False
    119 )
    120 return df_new, files_changed_lst, path_deleted_lst

File /global/common/software/m3805/conda/lib/python3.9/site-packages/pyfileindex/pyfileindex.py:54, in PyFileIndex._init_df_lst(self, path_lst, df, include_root)
     52     if include_root:
     53         total_lst.append(self._get_lst_entry_from_path(entry=p))
---> 54     for entry in list(self._scandir(path=p, df=df, recursive=True)):
     55         total_lst.append(entry)
     56 return self._create_df_from_lst(total_lst)

File /global/common/software/m3805/conda/lib/python3.9/site-packages/pyfileindex/pyfileindex.py:71, in PyFileIndex._scandir(self, path, df, recursive)
     59 """
     60 Internal function to recursivley scan directories
     61 
   (...)
     68     list: list of file entries
     69 """
     70 if df is not None and len(df) > 0:
---> 71     for entry in scandir(path):
     72         if entry.path not in df.path.values:
     73             if entry.is_dir(follow_symlinks=False) and recursive:
     74                 # yield from self._scandir(path=entry.path, df=df, recursive=recursive)  # Python 3.X only

FileNotFoundError: [Errno 2] No such file or directory: '/global/cscratch1/sd/janssen/adf_architector/script_hdf5/script/worker/adf_hdf5/adf/adf_814_hdf5/adf_814/ams.results'
FileNotFoundError: [Errno 2] No such file or directory: '/global/cscratch1/sd/janssen/adf_architector/script_hdf5/script/worker/adf_hdf5/adf/adf_814_hdf5/adf_814/ams.results'
```