### PR TITLE
Update numpy to 2.2.0

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -2,7 +2,7 @@ channels:
   - conda-forge
 dependencies:
   - coverage
-  - numpy =2.1.3
+  - numpy =2.2.0
   - pandas =2.2.3
   - scandir =1.10.0
   - setuptools =75.1.0


### PR DESCRIPTION
The tests in https://github.com/pyiron/pyfileindex/pull/164 failed and still the pull request was merged. This is dangerous. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `numpy` dependency to improve compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->