### PR TITLE
Bump setuptools from 80.1.0 to 80.3.1 (#195)

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -5,4 +5,4 @@ dependencies:
   - numpy =2.2.4
   - pandas =2.2.3
   - scandir =1.10.0
-  - setuptools =80.1.0
+  - setuptools =80.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "numpy==2.2.4",
     "pandas==2.2.3",
     "scandir==1.10.0",
-    "setuptools==80.1.0",
+    "setuptools==80.3.1",
     "versioneer[toml]==0.29",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
* Bump setuptools from 80.1.0 to 80.3.1

Bumps [setuptools](https://github.com/pypa/setuptools) from 80.1.0 to 80.3.1.
- [Release notes](https://github.com/pypa/setuptools/releases)
- [Changelog](https://github.com/pypa/setuptools/blob/main/NEWS.rst)
- [Commits](https://github.com/pypa/setuptools/compare/v80.1.0...v80.3.1)

---
updated-dependencies:
- dependency-name: setuptools dependency-version: 80.3.1 dependency-type: direct:production update-type: version-update:semver-minor ...



* [dependabot skip] Update environment

---------

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the required version of the setuptools package to 80.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->