### PR TITLE
Try hatch workaround

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -124,7 +124,7 @@ jobs:
       shell: bash -l {0}
       run: |
         pip install . --no-deps --no-build-isolation
-        coverage run --omit="pyfileindex/_version.py,tests/*" -m unittest discover tests
+        coverage run --omit="pyfileindex/_version.py,pyfileindex/version.py,tests/*" -m unittest discover tests
         coverage xml
     - name: Upload coverage reports to Codecov
       if: matrix.label == 'linux-64-py-3-12'

--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,9 @@
 .DS_Store
 .coverage
 nohup.out
-PyIron.log
-pyiron.log
 .idea/
 inspectionProfiles/
 _build/
 apidoc/
 .ipynb_checkpoints/
-test_times.dat
+pyfileindex/_version.py

--- a/pyfileindex/__init__.py
+++ b/pyfileindex/__init__.py
@@ -1,6 +1,5 @@
 from pyfileindex.pyfileindex import PyFileIndex
+from pyfileindex.version import __version__
 
-from . import _version
 
-__version__ = _version.__version__
-__all__ = ["PyFileIndex"]
+__all__ = ["PyFileIndex", "__version__"]

--- a/pyfileindex/_version.py
+++ b/pyfileindex/_version.py
@@ -17,5 +17,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = "0.0.1"
-__version_tuple__ = version_tuple = (0, 0, 1)
+__version__ = version = '0.0.37.dev0+gaac4df8.d20250522'
+__version_tuple__ = version_tuple = (0, 0, 37, 'dev0', 'gaac4df8.d20250522')

--- a/pyfileindex/_version.py
+++ b/pyfileindex/_version.py
@@ -17,5 +17,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = '0.0.37.dev0+gaac4df8.d20250522'
-__version_tuple__ = version_tuple = (0, 0, 37, 'dev0', 'gaac4df8.d20250522')
+__version__ = version = '0.0.1'
+__version_tuple__ = version_tuple = (0, 0, 1)

--- a/pyfileindex/version.py
+++ b/pyfileindex/version.py
@@ -1,0 +1,48 @@
+"""Compute the version number and store it in the `__version__` variable.
+
+Based on <https://github.com/maresb/hatch-vcs-footgun-example>.
+"""
+
+
+def _get_hatch_version():
+    """Compute the most up-to-date version number in a development environment.
+
+    Returns `None` if Hatchling is not installed, e.g. in a production environment.
+
+    For more details, see <https://github.com/maresb/hatch-vcs-footgun-example/>.
+    """
+    import os
+
+    try:
+        from hatchling.metadata.core import ProjectMetadata
+        from hatchling.plugin.manager import PluginManager
+        from hatchling.utils.fs import locate_file
+    except ImportError:
+        # Hatchling is not installed, so probably we are not in
+        # a development environment.
+        return None
+
+    pyproject_toml = locate_file(__file__, "pyproject.toml")
+    if pyproject_toml is None:
+        raise RuntimeError("pyproject.toml not found although hatchling is installed")
+    root = os.path.dirname(pyproject_toml)
+    metadata = ProjectMetadata(root=root, plugin_manager=PluginManager())
+    # Version can be either statically set in pyproject.toml or computed dynamically:
+    return metadata.core.version or metadata.hatch.version.cached
+
+
+def _get_importlib_metadata_version():
+    """Compute the version number using importlib.metadata.
+
+    This is the official Pythonic way to get the version number of an installed
+    package. However, it is only updated when a package is installed. Thus, if a
+    package is installed in editable mode, and a different version is checked out,
+    then the version number will not be updated.
+    """
+    from importlib.metadata import version
+
+    __version__ = version(__package__)
+    return __version__
+
+
+__version__ = _get_hatch_version() or _get_importlib_metadata_version()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,3 @@ packages = [
 [tool.hatch.version]
 source = "vcs"
 path = "pyfileindex/_version.py"
-
-[tool.hatch.version.raw-options]
-version_scheme = "no-guess-dev"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The package version is now accessible as part of the public API, allowing users to retrieve the version programmatically.
- **Refactor**
  - Improved version handling to dynamically determine the package version in both development and installed environments.
- **Chores**
  - Updated internal configuration and ignore files for better package management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->