### PR TITLE
Test with ARM

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -97,9 +97,9 @@ jobs:
           python-version: '3.13'
           label: linux-arm-22-py-3-13
 
-        - operating-system: windows-11-arm
+        - operating-system: windows-latest
           python-version: '3.13'
-          label: win-arm-py-3-13
+          label: win-64-py-3-13
 
         - operating-system: ubuntu-latest
           python-version: '3.13'

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -89,6 +89,18 @@ jobs:
           python-version: '3.13'
           label: osx-64-py-3-13
 
+        - operating-system: ubuntu-24.04-arm
+          python-version: '3.13'
+          label: linux-arm-24-py-3-13
+
+        - operating-system: ubuntu-22.04-arm
+          python-version: '3.13'
+          label: linux-arm-22-py-3-13
+
+        - operating-system: windows-11-arm
+          python-version: '3.13'
+          label: win-arm-py-3-13
+
         - operating-system: ubuntu-latest
           python-version: '3.13'
           label: linux-64-py-3-13

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -105,10 +105,6 @@ jobs:
           python-version: '3.13'
           label: linux-64-py-3-13
 
-        - operating-system: windows-latest
-          python-version: '3.13'
-          label: win-64-py-3-13
-
         - operating-system: ubuntu-latest
           python-version: '3.12'
           label: linux-64-py-3-12


### PR DESCRIPTION
Github introduced support for ARM runners on public repositories: https://github.blog/changelog/2025-08-07-arm64-hosted-runners-for-public-repositories-are-now-generally-available/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing environments for Python 3.13 to include additional ARM-based Ubuntu targets and adjusted the order of test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->