### PR TITLE
Update numpy to 2.3.2

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -4,6 +4,6 @@ dependencies:
   - coverage
   - hatchling =1.27.0
   - hatch-vcs =0.5.0
-  - numpy =2.2.4
+  - numpy =2.3.2
   - pandas =2.3.1
   - scandir =1.10.0

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -113,10 +113,6 @@ jobs:
           python-version: '3.11'
           label: linux-64-py-3-11
 
-        - operating-system: ubuntu-latest
-          python-version: '3.10'
-          label: linux-64-py-3-10
-
     steps:
     - uses: actions/checkout@v4
     - name: Conda config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "hatchling==1.27.0",
     "hatch-vcs==0.5.0",
-    "numpy==2.2.4",
+    "numpy==2.3.2",
     "pandas==2.3.1",
     "scandir==1.10.0",
 ]
@@ -31,7 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "numpy==2.2.4",
+    "numpy==2.3.2",
     "pandas==2.3.1",
     "scandir==1.10.0",
 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded NumPy dependency to version 2.3.2 across build and runtime.
  - Dependency specifications updated in project and build configuration.
  - Adjusted continuous integration by removing a Linux/Python 3.10 test job; testing continues on Windows, macOS, and Linux for Python 3.11–3.13.
  - No user-facing functionality changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->