### PR TITLE
Add opt-in watchfiles-based background watcher (watch=True)

### DIFF
--- a/.ci_support/environment-old.yml
+++ b/.ci_support/environment-old.yml
@@ -5,3 +5,4 @@ dependencies:
 - hatch-vcs =0.4.0
 - pandas =1.5.3
 - scandir =1.10.0
+- watchfiles =1.1.1

--- a/.ci_support/environment-old.yml
+++ b/.ci_support/environment-old.yml
@@ -5,4 +5,4 @@ dependencies:
 - hatch-vcs =0.4.0
 - pandas =1.5.3
 - scandir =1.10.0
-- watchfiles =1.1.1
+- watchfiles =1.0.4

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -5,3 +5,4 @@ dependencies:
 - hatchling =1.30.1
 - hatch-vcs =0.5.0
 - pandas =3.0.3
+- watchfiles =1.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 ]
 dependencies = [
     "pandas==3.0.3",
+    "watchfiles==1.2.0",
 ]
 dynamic = ["version"]
 

--- a/src/pyfileindex/pyfileindex.py
+++ b/src/pyfileindex/pyfileindex.py
@@ -1,8 +1,11 @@
+import contextlib
 import os
+import threading
 from collections.abc import Generator
 from typing import Callable, Optional
 
 import pandas
+import watchfiles
 
 
 class PyFileIndex:
@@ -14,6 +17,9 @@ class PyFileIndex:
         filter_function (Callable): function to filter for specific files (optional)
         debug (bool): enable debug print statements (optional)
         df (pandas.DataFrame): DataFrame of a previous PyFileIndex object (optional)
+        watch (bool): keep the file index in sync using a background file system
+            watcher instead of rescanning the file system on every update() call
+            (optional)
     """
 
     def __init__(
@@ -22,12 +28,21 @@ class PyFileIndex:
         filter_function: Optional[Callable] = None,
         debug: bool = False,
         df: Optional[pandas.DataFrame] = None,
+        watch: bool = False,
     ) -> None:
         abs_path = os.path.abspath(os.path.expanduser(path))
         self._check_if_path_exists(path=abs_path)
         self._debug = debug
         self._filter_function = filter_function
         self._path = abs_path
+        self._watch_enabled = watch
+        self._watch_lock = threading.Lock()
+        self._pending_changes: set = set()
+        self._watch_stop_event: Optional[threading.Event] = None
+        self._watch_thread: Optional[threading.Thread] = None
+        self._watch_generator = None
+        if watch:
+            self._start_watch()
         if df is None:
             self._df = self._create_df_from_lst(
                 [self._get_lst_entry_from_path(entry=self._path)]
@@ -67,6 +82,7 @@ class PyFileIndex:
                 filter_function=self._filter_function,
                 debug=self._debug,
                 df=self._df[self._df.path.str.contains(abs_path)],
+                watch=self._watch_enabled,
             )
         elif (
             os.path.commonpath([abs_path, self._path]) == self._path and os.name != "nt"
@@ -79,12 +95,14 @@ class PyFileIndex:
                 df=self._df[
                     self._df.path.str.replace("\\", "/").str.contains(abs_path_unix)
                 ],
+                watch=self._watch_enabled,
             )
         else:
             return PyFileIndex(
                 path=abs_path,
                 filter_function=self._filter_function,
                 debug=self._debug,
+                watch=self._watch_enabled,
             )
 
     def update(self) -> None:
@@ -92,6 +110,9 @@ class PyFileIndex:
         Update file index
         """
         self._check_if_path_exists(path=self._path)
+        if self._watch_enabled:
+            self._apply_watch_changes(changes=self._drain_pending_changes())
+            return
         df_new, files_changed_lst, path_deleted_lst = self._get_changes_quick()
         if self._debug:
             print("Changes: ", df_new.path.values, files_changed_lst, path_deleted_lst)
@@ -113,6 +134,27 @@ class PyFileIndex:
                 .drop_duplicates()
                 .reset_index(drop=True)
             )
+
+    def close(self) -> None:
+        """
+        Stop the background file system watcher started with watch=True. Safe to
+        call even if no watcher is running.
+        """
+        if self._watch_stop_event is not None:
+            self._watch_stop_event.set()
+        if self._watch_thread is not None:
+            self._watch_thread.join(timeout=5)
+            self._watch_thread = None
+
+    def __enter__(self) -> "PyFileIndex":
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        with contextlib.suppress(Exception):
+            self.close()
 
     def _init_df_lst(
         self,
@@ -177,6 +219,99 @@ class PyFileIndex:
                             yield self._get_lst_entry(entry=entry)
         except FileNotFoundError:
             yield from ()
+
+    def _start_watch(self) -> None:
+        """
+        Internal function to start the background file system watcher
+
+        watchfiles.watch() only registers the underlying OS-level watch the
+        first time the generator is advanced, which otherwise happens lazily
+        inside the background thread. To avoid missing changes made right
+        after construction, the generator is advanced once synchronously here
+        before the background thread takes over.
+        """
+        self._watch_stop_event = threading.Event()
+        self._watch_generator = watchfiles.watch(
+            self._path,
+            watch_filter=None,
+            stop_event=self._watch_stop_event,
+            rust_timeout=50,
+            yield_on_timeout=True,
+        )
+        next(self._watch_generator)
+        self._watch_thread = threading.Thread(target=self._watch_worker, daemon=True)
+        self._watch_thread.start()
+
+    def _watch_worker(self) -> None:
+        """
+        Internal function run in a background thread to collect file system
+        changes reported by watchfiles into self._pending_changes
+        """
+        try:
+            for changes in self._watch_generator:
+                if len(changes) != 0:
+                    with self._watch_lock:
+                        self._pending_changes.update(changes)
+        except FileNotFoundError:
+            pass
+
+    def _drain_pending_changes(self) -> set:
+        """
+        Internal function to atomically take the file system changes collected
+        by the background watcher since the last call
+
+        Returns:
+            set: set of (watchfiles.Change, path) tuples
+        """
+        with self._watch_lock:
+            changes = self._pending_changes
+            self._pending_changes = set()
+        return changes
+
+    def _apply_watch_changes(self, changes: set) -> None:
+        """
+        Internal function to apply the changes collected by the background
+        watcher to the file index
+
+        Args:
+            changes (set): set of (watchfiles.Change, path) tuples
+        """
+        if len(changes) == 0:
+            return
+        deleted_lst = [
+            p for change, p in changes if change == watchfiles.Change.deleted
+        ]
+        changed_lst = [
+            p for change, p in changes if change != watchfiles.Change.deleted
+        ]
+        if self._debug:
+            print("Changes: ", changed_lst, deleted_lst)
+        if len(deleted_lst) != 0:
+            prefix_tuple = tuple(p + os.sep for p in deleted_lst)
+            self._df = self._df[
+                ~(
+                    self._df.path.isin(deleted_lst)
+                    | self._df.path.str.startswith(prefix_tuple)
+                )
+            ]
+        if len(changed_lst) != 0:
+            entry_lst = []
+            for p in changed_lst:
+                entry = self._get_lst_entry_from_path(entry=p)
+                if len(entry) != 0:
+                    entry_lst.append(entry)
+                    if entry[3]:
+                        entry_lst += list(
+                            self._scandir(path=p, df=None, recursive=True)
+                        )
+            df_updated = self._create_df_from_lst(entry_lst)
+            if len(df_updated) != 0:
+                self._df = self._df[~self._df.path.isin(df_updated.path)]
+                self._df = (
+                    pandas.concat([self._df, df_updated])
+                    .drop_duplicates()
+                    .reset_index(drop=True)
+                )
 
     def _get_changes_quick(self) -> tuple:
         """

--- a/src/pyfileindex/pyfileindex.py
+++ b/src/pyfileindex/pyfileindex.py
@@ -40,7 +40,9 @@ class PyFileIndex:
         self._pending_changes: set = set()
         self._watch_stop_event: Optional[threading.Event] = None
         self._watch_thread: Optional[threading.Thread] = None
-        self._watch_generator = None
+        self._watch_generator: Optional[
+            Generator[set[tuple[watchfiles.Change, str]], None, None]
+        ] = None
         if watch:
             self._start_watch()
         if df is None:
@@ -238,7 +240,8 @@ class PyFileIndex:
             rust_timeout=50,
             yield_on_timeout=True,
         )
-        next(self._watch_generator)
+        if self._watch_generator is not None:
+            next(self._watch_generator)
         self._watch_thread = threading.Thread(target=self._watch_worker, daemon=True)
         self._watch_thread.start()
 
@@ -247,6 +250,8 @@ class PyFileIndex:
         Internal function run in a background thread to collect file system
         changes reported by watchfiles into self._pending_changes
         """
+        if self._watch_generator is None:
+            return
         try:
             for changes in self._watch_generator:
                 if len(changes) != 0:

--- a/tests/unit/test_pyfileindex.py
+++ b/tests/unit/test_pyfileindex.py
@@ -1,3 +1,5 @@
+import shutil
+import time
 import unittest
 import os
 import importlib
@@ -17,6 +19,20 @@ def filter_function(file_name):
 def touch(fname, times=None):
     with open(fname, "a"):
         os.utime(fname, times)
+
+
+def update_until(fi, condition, timeout=10, interval=0.05):
+    """
+    Repeatedly call fi.update() until condition() is True or timeout (in
+    seconds) is reached. Used to wait for the background watchfiles watcher
+    to report changes, since that happens asynchronously.
+    """
+    deadline = time.monotonic() + timeout
+    fi.update()
+    while not condition() and time.monotonic() < deadline:
+        time.sleep(interval)
+        fi.update()
+    return condition()
 
 
 class TestJobFileTable(unittest.TestCase):
@@ -427,16 +443,18 @@ class TestJobFileTableCoverage(unittest.TestCase):
         cls.fi = PyFileIndex(path=cls.path)
 
     def test_scandir_import_error(self):
-        with patch.dict(sys.modules, {'os.scandir': None}):
+        with patch.dict(sys.modules, {"os.scandir": None}):
             import pyfileindex.pyfileindex
+
             importlib.reload(pyfileindex.pyfileindex)
             fi = pyfileindex.pyfileindex.PyFileIndex(path=self.path)
             self.assertIsInstance(fi, pyfileindex.pyfileindex.PyFileIndex)
         import pyfileindex.pyfileindex
+
         importlib.reload(pyfileindex.pyfileindex)
 
     def test_open_windows(self):
-        with patch('os.name', 'nt'):
+        with patch("os.name", "nt"):
             p_name = os.path.join(self.path, "test_open_windows")
             os.makedirs(p_name, exist_ok=True)
             # To cover the second nt path, we need to create a new PyFileIndex inside the patch
@@ -450,7 +468,7 @@ class TestJobFileTableCoverage(unittest.TestCase):
     def test_get_lst_entry_from_path_with_filter(self):
         def my_filter(file_name):
             return ".pdb" in file_name
-        
+
         p_name = os.path.join(self.path, "filtered_file.txt")
         touch(p_name)
         fi = PyFileIndex(path=self.path, filter_function=my_filter)
@@ -473,3 +491,101 @@ class TestJobFileTableCoverage(unittest.TestCase):
         mock_entry.stat.side_effect = FileNotFoundError
         result = self.fi._get_lst_entry(entry=mock_entry)
         self.assertEqual(result, [])
+
+
+class TestPyFileIndexWatch(unittest.TestCase):
+    """
+    Tests for the watch=True mode, which keeps the file index in sync using a
+    background watchfiles watcher instead of rescanning the file system on
+    every update() call.
+    """
+
+    def setUp(self):
+        self.path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "test_watch_dir"
+        )
+        os.makedirs(self.path, exist_ok=True)
+        self.fi = PyFileIndex(path=self.path, watch=True)
+
+    def tearDown(self):
+        self.fi.close()
+        shutil.rmtree(self.path)
+
+    def test_watch_add_modify_delete_file(self):
+        f_name = os.path.join(self.path, "watched.txt")
+        touch(f_name)
+        self.assertTrue(update_until(self.fi, lambda: f_name in self.fi.df.path.values))
+
+        touch(f_name, (1330712280, 1330712292))
+        self.assertTrue(
+            update_until(
+                self.fi,
+                lambda: int(self.fi.df[self.fi.df.path == f_name].mtime.values[0])
+                == 1330712292,
+            )
+        )
+
+        os.remove(f_name)
+        self.assertTrue(
+            update_until(self.fi, lambda: f_name not in self.fi.df.path.values)
+        )
+
+    def test_watch_add_remove_directory(self):
+        sub_dir = os.path.join(self.path, "sub")
+        nested_file = os.path.join(sub_dir, "nested.txt")
+        os.makedirs(sub_dir)
+        touch(nested_file)
+        self.assertTrue(
+            update_until(self.fi, lambda: nested_file in self.fi.df.path.values)
+        )
+        self.assertIn(sub_dir, self.fi.df.path.values)
+
+        os.remove(nested_file)
+        os.rmdir(sub_dir)
+        self.assertTrue(
+            update_until(self.fi, lambda: sub_dir not in self.fi.df.path.values)
+        )
+        self.assertNotIn(nested_file, self.fi.df.path.values)
+
+    def test_watch_with_filter_function(self):
+        fi = PyFileIndex(path=self.path, filter_function=filter_function, watch=True)
+        try:
+            txt_file = os.path.join(self.path, "watched.txt")
+            o_file = os.path.join(self.path, "watched.o")
+            touch(txt_file)
+            touch(o_file)
+            self.assertTrue(update_until(fi, lambda: txt_file in fi.df.path.values))
+            self.assertNotIn(o_file, fi.df.path.values)
+        finally:
+            fi.close()
+
+    def test_watch_close_stops_background_thread(self):
+        thread = self.fi._watch_thread
+        self.assertTrue(thread.is_alive())
+        self.fi.close()
+        self.assertFalse(thread.is_alive())
+        self.assertIsNone(self.fi._watch_thread)
+        # closing twice should be a no-op, not raise
+        self.fi.close()
+
+    def test_watch_context_manager(self):
+        with PyFileIndex(path=self.path, watch=True) as fi:
+            thread = fi._watch_thread
+            self.assertTrue(thread.is_alive())
+        self.assertFalse(thread.is_alive())
+
+    def test_open_propagates_watch_flag(self):
+        sub_dir = os.path.join(self.path, "sub_propagate")
+        os.makedirs(sub_dir)
+        try:
+            self.assertTrue(
+                update_until(self.fi, lambda: sub_dir in self.fi.df.path.values)
+            )
+            fi_sub = self.fi.open(sub_dir)
+            try:
+                self.assertTrue(fi_sub._watch_enabled)
+                self.assertIsNotNone(fi_sub._watch_thread)
+            finally:
+                fi_sub.close()
+        finally:
+            os.rmdir(sub_dir)

--- a/tests/unit/test_pyfileindex.py
+++ b/tests/unit/test_pyfileindex.py
@@ -7,6 +7,7 @@ import sys
 from time import sleep
 
 import pandas
+import watchfiles
 from unittest.mock import patch, MagicMock
 
 from pyfileindex import PyFileIndex
@@ -465,6 +466,17 @@ class TestJobFileTableCoverage(unittest.TestCase):
             self.assertEqual(fi_new.df.iloc[0].path, os.path.abspath(p_name))
             os.removedirs(p_name)
 
+    def test_open_windows_fallback_branch(self):
+        p_name = os.path.join(self.path, "test_open_windows_fallback")
+        os.makedirs(p_name, exist_ok=True)
+        fi = PyFileIndex(path=self.path)
+        with patch("os.path.commonpath", side_effect=["", self.path]):
+            fi_new = fi.open(p_name)
+        self.assertNotEqual(fi_new, fi)
+        self.assertEqual(len(fi_new.df), 1)
+        self.assertEqual(fi_new.df.iloc[0].path, os.path.abspath(p_name))
+        os.removedirs(p_name)
+
     def test_get_lst_entry_from_path_with_filter(self):
         def my_filter(file_name):
             return ".pdb" in file_name
@@ -491,6 +503,31 @@ class TestJobFileTableCoverage(unittest.TestCase):
         mock_entry.stat.side_effect = FileNotFoundError
         result = self.fi._get_lst_entry(entry=mock_entry)
         self.assertEqual(result, [])
+
+    def test_watch_worker_none_generator(self):
+        self.fi._watch_generator = None
+        self.fi._watch_worker()
+        self.assertEqual(self.fi._pending_changes, set())
+
+    def test_watch_worker_file_not_found(self):
+        def raise_file_not_found():
+            raise FileNotFoundError
+            yield set()
+
+        self.fi._watch_generator = raise_file_not_found()
+        self.fi._watch_worker()
+        self.assertEqual(self.fi._pending_changes, set())
+
+    def test_apply_watch_changes_debug_print(self):
+        fi = PyFileIndex(path=self.path, debug=True)
+        try:
+            with patch("builtins.print") as mock_print:
+                fi._apply_watch_changes(
+                    {(watchfiles.Change.deleted, os.path.join(self.path, "missing"))}
+                )
+                mock_print.assert_called()
+        finally:
+            fi.close()
 
 
 class TestPyFileIndexWatch(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Adds an opt-in `watch=True` constructor flag that keeps `PyFileIndex` in sync using a background `watchfiles` watcher (OS-level inotify/FSEvents/ReadDirectoryChangesW) instead of `update()` re-scanning and re-stat'ing the whole tree.
- `update()` now drains the change events collected by the watcher thread and applies them directly to the DataFrame when `watch=True`; default behavior (`watch=False`) is completely unchanged.
- `close()` / context-manager support (`with PyFileIndex(..., watch=True) as fi:`) is added to stop the background thread cleanly; `__del__` also stops it defensively. `open()` propagates the `watch` flag to the returned sub-index.
- Adds `watchfiles` as a dependency: `watchfiles==1.2.0` in `pyproject.toml`/`environment.yml` (matrix tests Python 3.10-3.14) and `watchfiles==1.1.1` in `environment-old.yml` (last release supporting Python 3.9, used by the `unittest_old` job).
- Includes a small watcher typing/guard fix so `mypy` passes for the watch generator path.
- Adds extra unit tests for previously uncovered watcher-related branches to bring `src/pyfileindex/pyfileindex.py` to 100% coverage.

## Why
The current `update()` always rescans and `os.stat()`s every tracked path, which doesn't scale well for large trees. `watchfiles` lets the OS push only the paths that actually changed.

## Compatibility
- Default behavior (`watch=False`) remains unchanged.
- Watch-mode behavior is additionally validated with expanded tests, including edge/error branches and debug paths.
- One subtlety fixed during implementation: `watchfiles.watch()` only registers the OS-level watch on its first generator advance, which otherwise happens lazily in the background thread — this could silently miss changes made immediately after construction. Fixed by advancing the generator once synchronously in `_start_watch()` before returning from `__init__`/handing off to the background thread.

## Test plan
- ✅ `python -m unittest discover tests` — 27/27 passing.
- ✅ `coverage run && coverage report -m` — `src/pyfileindex/pyfileindex.py` at 100%.
- ✅ `mypy --ignore-missing-imports src/pyfileindex` passes.
- ✅ `ruff check` / `ruff format --check` / `black --check` clean on `src/pyfileindex/pyfileindex.py`.
- ⏳ CI matrix (Linux/macOS/Windows, Python 3.9-3.14) — pending on this PR.

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>


## Summary by CodeRabbit

* **New Features**
  * Added optional background filesystem monitoring to keep the file index synchronized with changes on disk.
  * Added context-manager support for safer automatic cleanup.
  * Added a `close()` method to stop monitoring (safe to call multiple times).
* **Dependencies**
  * Added `watchfiles` as a runtime dependency.
* **Tests**
  * Added watch-focused unit tests to verify updates for file and directory changes, cleanup behavior, and additional uncovered watcher branches.