### PR TITLE
Make watchfiles an optional dependency

### DIFF
--- a/.ci_support/environment-mini.yml
+++ b/.ci_support/environment-mini.yml
@@ -1,7 +1,7 @@
 channels:
 - conda-forge
 dependencies:
-- python
+- coverage
 - hatchling =1.30.1
 - hatch-vcs =0.5.0
 - pandas =3.0.3

--- a/.ci_support/environment-mini.yml
+++ b/.ci_support/environment-mini.yml
@@ -5,4 +5,3 @@ dependencies:
 - hatchling =1.30.1
 - hatch-vcs =0.5.0
 - pandas =3.0.3
-- watchfiles =1.2.0

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -91,6 +91,26 @@ jobs:
         uv sync --all-extras --dev
         pip check
 
+  minimal:
+    needs: [black]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Conda config
+      shell: bash -l {0}
+      run: echo -e "channels:\n  - conda-forge\n" > .condarc
+    - uses: conda-incubator/setup-miniconda@v3
+      with:
+        python-version: '3.14'
+        miniforge-version: latest
+        condarc-file: .condarc
+        environment-file: .ci_support/environment.yml
+    - name: Test
+      shell: bash -l {0}
+      run: |
+        pip install . --no-deps --no-build-isolation
+        python -m unittest discover tests
+
   unittest_matrix:
     needs: [black]
     runs-on: ${{ matrix.operating-system }}
@@ -172,7 +192,7 @@ jobs:
         python -m unittest discover tests
 
   autobot:
-    needs: [uv_check, unittest_old, unittest_matrix, pip_check, mypy]
+    needs: [uv_check, unittest_old, unittest_matrix, pip_check, mypy, minimal]
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -104,7 +104,7 @@ jobs:
         python-version: '3.14'
         miniforge-version: latest
         condarc-file: .condarc
-        environment-file: .ci_support/environment.yml
+        environment-file: .ci_support/environment-mini.yml
     - name: Test
       shell: bash -l {0}
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,11 @@ classifiers = [
 ]
 dependencies = [
     "pandas==3.0.3",
-    "watchfiles==1.2.0",
 ]
 dynamic = ["version"]
+
+[project.optional-dependencies]
+watchfiles = ["watchfiles==1.2.0"]
 
 [project.urls]
 Homepage = "https://github.com/pyiron/pyfileindex"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ select = [
 ignore = [
     # ignore line-length violations
     "E501",
+    # ignore imports which are not at the top of a module
+    "PLC0415",
 ]
 
 [tool.hatch.build]

--- a/src/pyfileindex/pyfileindex.py
+++ b/src/pyfileindex/pyfileindex.py
@@ -40,7 +40,7 @@ class PyFileIndex:
         self._watch_stop_event: Optional[threading.Event] = None
         self._watch_thread: Optional[threading.Thread] = None
         self._watch_generator: Optional[
-            Generator[set[tuple[watchfiles.Change, str]], None, None]
+            Generator[set[tuple], None, None]
         ] = None
         if watch:
             self._start_watch()

--- a/src/pyfileindex/pyfileindex.py
+++ b/src/pyfileindex/pyfileindex.py
@@ -40,7 +40,7 @@ class PyFileIndex:
         self._watch_stop_event: Optional[threading.Event] = None
         self._watch_thread: Optional[threading.Thread] = None
         self._watch_generator: Optional[
-            Generator[set[tuple[watchfiles.Change, str]], None, None]
+            Generator[set[tuple["watchfiles.Change", str]], None, None]
         ] = None
         if watch:
             self._start_watch()

--- a/src/pyfileindex/pyfileindex.py
+++ b/src/pyfileindex/pyfileindex.py
@@ -40,7 +40,7 @@ class PyFileIndex:
         self._watch_stop_event: Optional[threading.Event] = None
         self._watch_thread: Optional[threading.Thread] = None
         self._watch_generator: Optional[
-            Generator[set[tuple["watchfiles.Change", str]], None, None]
+            Generator[set[tuple[watchfiles.Change, str]], None, None]
         ] = None
         if watch:
             self._start_watch()

--- a/src/pyfileindex/pyfileindex.py
+++ b/src/pyfileindex/pyfileindex.py
@@ -5,7 +5,6 @@ from collections.abc import Generator
 from typing import Callable, Optional
 
 import pandas
-import watchfiles
 
 
 class PyFileIndex:
@@ -232,6 +231,8 @@ class PyFileIndex:
         after construction, the generator is advanced once synchronously here
         before the background thread takes over.
         """
+        import watchfiles
+
         self._watch_stop_event = threading.Event()
         self._watch_generator = watchfiles.watch(
             self._path,
@@ -281,6 +282,8 @@ class PyFileIndex:
         Args:
             changes (set): set of (watchfiles.Change, path) tuples
         """
+        import watchfiles
+
         if len(changes) == 0:
             return
         deleted_lst = [

--- a/src/pyfileindex/pyfileindex.py
+++ b/src/pyfileindex/pyfileindex.py
@@ -39,9 +39,7 @@ class PyFileIndex:
         self._pending_changes: set = set()
         self._watch_stop_event: Optional[threading.Event] = None
         self._watch_thread: Optional[threading.Thread] = None
-        self._watch_generator: Optional[
-            Generator[set[tuple], None, None]
-        ] = None
+        self._watch_generator: Optional[Generator[set[tuple], None, None]] = None
         if watch:
             self._start_watch()
         if df is None:

--- a/tests/unit/test_pyfileindex.py
+++ b/tests/unit/test_pyfileindex.py
@@ -388,7 +388,7 @@ class TestJobFileTable(unittest.TestCase):
 
     def test_len(self):
         self.assertEqual(0, len(self.fi_with_filter))
-        self.assertEqual(4, len(self.fi_without_filter))
+        self.assertEqual(6, len(self.fi_without_filter))
         self.assertEqual(0, len(self.fi_debug))
 
     def test_open(self):
@@ -501,28 +501,3 @@ class TestJobFileTableCoverage(unittest.TestCase):
         mock_entry.stat.side_effect = FileNotFoundError
         result = self.fi._get_lst_entry(entry=mock_entry)
         self.assertEqual(result, [])
-
-    def test_watch_worker_none_generator(self):
-        self.fi._watch_generator = None
-        self.fi._watch_worker()
-        self.assertEqual(self.fi._pending_changes, set())
-
-    def test_watch_worker_file_not_found(self):
-        def raise_file_not_found():
-            raise FileNotFoundError
-            yield set()
-
-        self.fi._watch_generator = raise_file_not_found()
-        self.fi._watch_worker()
-        self.assertEqual(self.fi._pending_changes, set())
-
-    def test_apply_watch_changes_debug_print(self):
-        fi = PyFileIndex(path=self.path, debug=True)
-        try:
-            with patch("builtins.print") as mock_print:
-                fi._apply_watch_changes(
-                    {(watchfiles.Change.deleted, os.path.join(self.path, "missing"))}
-                )
-                mock_print.assert_called()
-        finally:
-            fi.close()

--- a/tests/unit/test_pyfileindex.py
+++ b/tests/unit/test_pyfileindex.py
@@ -1,4 +1,3 @@
-import shutil
 import time
 import unittest
 import os
@@ -7,7 +6,6 @@ import sys
 from time import sleep
 
 import pandas
-import watchfiles
 from unittest.mock import patch, MagicMock
 
 from pyfileindex import PyFileIndex
@@ -528,101 +526,3 @@ class TestJobFileTableCoverage(unittest.TestCase):
                 mock_print.assert_called()
         finally:
             fi.close()
-
-
-class TestPyFileIndexWatch(unittest.TestCase):
-    """
-    Tests for the watch=True mode, which keeps the file index in sync using a
-    background watchfiles watcher instead of rescanning the file system on
-    every update() call.
-    """
-
-    def setUp(self):
-        self.path = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "test_watch_dir"
-        )
-        os.makedirs(self.path, exist_ok=True)
-        self.fi = PyFileIndex(path=self.path, watch=True)
-
-    def tearDown(self):
-        self.fi.close()
-        shutil.rmtree(self.path)
-
-    def test_watch_add_modify_delete_file(self):
-        f_name = os.path.join(self.path, "watched.txt")
-        touch(f_name)
-        self.assertTrue(update_until(self.fi, lambda: f_name in self.fi.df.path.values))
-
-        touch(f_name, (1330712280, 1330712292))
-        self.assertTrue(
-            update_until(
-                self.fi,
-                lambda: int(self.fi.df[self.fi.df.path == f_name].mtime.values[0])
-                == 1330712292,
-            )
-        )
-
-        os.remove(f_name)
-        self.assertTrue(
-            update_until(self.fi, lambda: f_name not in self.fi.df.path.values)
-        )
-
-    def test_watch_add_remove_directory(self):
-        sub_dir = os.path.join(self.path, "sub")
-        nested_file = os.path.join(sub_dir, "nested.txt")
-        os.makedirs(sub_dir)
-        touch(nested_file)
-        self.assertTrue(
-            update_until(self.fi, lambda: nested_file in self.fi.df.path.values)
-        )
-        self.assertIn(sub_dir, self.fi.df.path.values)
-
-        os.remove(nested_file)
-        os.rmdir(sub_dir)
-        self.assertTrue(
-            update_until(self.fi, lambda: sub_dir not in self.fi.df.path.values)
-        )
-        self.assertNotIn(nested_file, self.fi.df.path.values)
-
-    def test_watch_with_filter_function(self):
-        fi = PyFileIndex(path=self.path, filter_function=filter_function, watch=True)
-        try:
-            txt_file = os.path.join(self.path, "watched.txt")
-            o_file = os.path.join(self.path, "watched.o")
-            touch(txt_file)
-            touch(o_file)
-            self.assertTrue(update_until(fi, lambda: txt_file in fi.df.path.values))
-            self.assertNotIn(o_file, fi.df.path.values)
-        finally:
-            fi.close()
-
-    def test_watch_close_stops_background_thread(self):
-        thread = self.fi._watch_thread
-        self.assertTrue(thread.is_alive())
-        self.fi.close()
-        self.assertFalse(thread.is_alive())
-        self.assertIsNone(self.fi._watch_thread)
-        # closing twice should be a no-op, not raise
-        self.fi.close()
-
-    def test_watch_context_manager(self):
-        with PyFileIndex(path=self.path, watch=True) as fi:
-            thread = fi._watch_thread
-            self.assertTrue(thread.is_alive())
-        self.assertFalse(thread.is_alive())
-
-    def test_open_propagates_watch_flag(self):
-        sub_dir = os.path.join(self.path, "sub_propagate")
-        os.makedirs(sub_dir)
-        try:
-            self.assertTrue(
-                update_until(self.fi, lambda: sub_dir in self.fi.df.path.values)
-            )
-            fi_sub = self.fi.open(sub_dir)
-            try:
-                self.assertTrue(fi_sub._watch_enabled)
-                self.assertIsNotNone(fi_sub._watch_thread)
-            finally:
-                fi_sub.close()
-        finally:
-            os.rmdir(sub_dir)

--- a/tests/unit/test_watchfiles.py
+++ b/tests/unit/test_watchfiles.py
@@ -1,0 +1,132 @@
+import shutil
+import time
+import unittest
+import os
+
+from pyfileindex import PyFileIndex
+
+try:
+    import watchfiles
+except ImportError:
+    raise unittest.SkipTest("watchfiles is required for these tests")
+
+
+def filter_function(file_name):
+    return ".txt" in file_name
+
+
+def touch(fname, times=None):
+    with open(fname, "a"):
+        os.utime(fname, times)
+
+
+def update_until(fi, condition, timeout=10, interval=0.05):
+    """
+    Repeatedly call fi.update() until condition() is True or timeout (in
+    seconds) is reached. Used to wait for the background watchfiles watcher
+    to report changes, since that happens asynchronously.
+    """
+    deadline = time.monotonic() + timeout
+    fi.update()
+    while not condition() and time.monotonic() < deadline:
+        time.sleep(interval)
+        fi.update()
+    return condition()
+
+
+class TestPyFileIndexWatch(unittest.TestCase):
+    """
+    Tests for the watch=True mode, which keeps the file index in sync using a
+    background watchfiles watcher instead of rescanning the file system on
+    every update() call.
+    """
+
+    def setUp(self):
+        self.path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "test_watch_dir"
+        )
+        os.makedirs(self.path, exist_ok=True)
+        self.fi = PyFileIndex(path=self.path, watch=True)
+
+    def tearDown(self):
+        self.fi.close()
+        shutil.rmtree(self.path)
+
+    def test_watch_add_modify_delete_file(self):
+        f_name = os.path.join(self.path, "watched.txt")
+        touch(f_name)
+        self.assertTrue(update_until(self.fi, lambda: f_name in self.fi.df.path.values))
+
+        touch(f_name, (1330712280, 1330712292))
+        self.assertTrue(
+            update_until(
+                self.fi,
+                lambda: int(self.fi.df[self.fi.df.path == f_name].mtime.values[0])
+                == 1330712292,
+            )
+        )
+
+        os.remove(f_name)
+        self.assertTrue(
+            update_until(self.fi, lambda: f_name not in self.fi.df.path.values)
+        )
+
+    def test_watch_add_remove_directory(self):
+        sub_dir = os.path.join(self.path, "sub")
+        nested_file = os.path.join(sub_dir, "nested.txt")
+        os.makedirs(sub_dir)
+        touch(nested_file)
+        self.assertTrue(
+            update_until(self.fi, lambda: nested_file in self.fi.df.path.values)
+        )
+        self.assertIn(sub_dir, self.fi.df.path.values)
+
+        os.remove(nested_file)
+        os.rmdir(sub_dir)
+        self.assertTrue(
+            update_until(self.fi, lambda: sub_dir not in self.fi.df.path.values)
+        )
+        self.assertNotIn(nested_file, self.fi.df.path.values)
+
+    def test_watch_with_filter_function(self):
+        fi = PyFileIndex(path=self.path, filter_function=filter_function, watch=True)
+        try:
+            txt_file = os.path.join(self.path, "watched.txt")
+            o_file = os.path.join(self.path, "watched.o")
+            touch(txt_file)
+            touch(o_file)
+            self.assertTrue(update_until(fi, lambda: txt_file in fi.df.path.values))
+            self.assertNotIn(o_file, fi.df.path.values)
+        finally:
+            fi.close()
+
+    def test_watch_close_stops_background_thread(self):
+        thread = self.fi._watch_thread
+        self.assertTrue(thread.is_alive())
+        self.fi.close()
+        self.assertFalse(thread.is_alive())
+        self.assertIsNone(self.fi._watch_thread)
+        # closing twice should be a no-op, not raise
+        self.fi.close()
+
+    def test_watch_context_manager(self):
+        with PyFileIndex(path=self.path, watch=True) as fi:
+            thread = fi._watch_thread
+            self.assertTrue(thread.is_alive())
+        self.assertFalse(thread.is_alive())
+
+    def test_open_propagates_watch_flag(self):
+        sub_dir = os.path.join(self.path, "sub_propagate")
+        os.makedirs(sub_dir)
+        try:
+            self.assertTrue(
+                update_until(self.fi, lambda: sub_dir in self.fi.df.path.values)
+            )
+            fi_sub = self.fi.open(sub_dir)
+            try:
+                self.assertTrue(fi_sub._watch_enabled)
+                self.assertIsNotNone(fi_sub._watch_thread)
+            finally:
+                fi_sub.close()
+        finally:
+            os.rmdir(sub_dir)

--- a/tests/unit/test_watchfiles.py
+++ b/tests/unit/test_watchfiles.py
@@ -3,6 +3,8 @@ import time
 import unittest
 import os
 
+from unittest.mock import patch
+
 from pyfileindex import PyFileIndex
 
 try:
@@ -130,3 +132,35 @@ class TestPyFileIndexWatch(unittest.TestCase):
                 fi_sub.close()
         finally:
             os.rmdir(sub_dir)
+
+
+class TestJobFileTableCoverage(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.path = os.path.dirname(os.path.abspath(__file__))
+        cls.fi = PyFileIndex(path=cls.path)
+
+    def test_watch_worker_none_generator(self):
+        self.fi._watch_generator = None
+        self.fi._watch_worker()
+        self.assertEqual(self.fi._pending_changes, set())
+
+    def test_watch_worker_file_not_found(self):
+        def raise_file_not_found():
+            raise FileNotFoundError
+            yield set()
+
+        self.fi._watch_generator = raise_file_not_found()
+        self.fi._watch_worker()
+        self.assertEqual(self.fi._pending_changes, set())
+
+    def test_apply_watch_changes_debug_print(self):
+        fi = PyFileIndex(path=self.path, debug=True)
+        try:
+            with patch("builtins.print") as mock_print:
+                fi._apply_watch_changes(
+                    {(watchfiles.Change.deleted, os.path.join(self.path, "missing"))}
+                )
+                mock_print.assert_called()
+        finally:
+            fi.close()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File watching is now available as an optional feature (install the added `watchfiles` extra when needed).

* **Tests**
  * Added dedicated unit tests for `watch=True` behavior when the watcher dependency is available.
  * Removed the previous watch-mode test coverage from the older test module.

* **CI / Automation**
  * Added a new minimal CI job using Python 3.14 to run the unit test suite.
  * Updated auto-merge requirements to include the new job.

* **Chores**
  * Improved responsiveness by deferring the watcher dependency import until watch mode is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->