### PR TITLE
Move watchfiles background watcher to its own submodule

### DIFF
--- a/src/pyfileindex/pyfileindex.py
+++ b/src/pyfileindex/pyfileindex.py
@@ -1,10 +1,11 @@
 import contextlib
 import os
-import threading
 from collections.abc import Generator
 from typing import Callable, Optional
 
 import pandas
+
+from pyfileindex.watcher import FileSystemWatcher
 
 
 class PyFileIndex:
@@ -35,13 +36,10 @@ class PyFileIndex:
         self._filter_function = filter_function
         self._path = abs_path
         self._watch_enabled = watch
-        self._watch_lock = threading.Lock()
-        self._pending_changes: set = set()
-        self._watch_stop_event: Optional[threading.Event] = None
-        self._watch_thread: Optional[threading.Thread] = None
-        self._watch_generator: Optional[Generator[set[tuple], None, None]] = None
+        self._watcher: Optional[FileSystemWatcher] = None
         if watch:
-            self._start_watch()
+            self._watcher = FileSystemWatcher(path=self._path)
+            self._watcher.start()
         if df is None:
             self._df = self._create_df_from_lst(
                 [self._get_lst_entry_from_path(entry=self._path)]
@@ -109,8 +107,8 @@ class PyFileIndex:
         Update file index
         """
         self._check_if_path_exists(path=self._path)
-        if self._watch_enabled:
-            self._apply_watch_changes(changes=self._drain_pending_changes())
+        if self._watcher is not None:
+            self._apply_watch_changes(changes=self._watcher.drain_pending_changes())
             return
         df_new, files_changed_lst, path_deleted_lst = self._get_changes_quick()
         if self._debug:
@@ -139,11 +137,8 @@ class PyFileIndex:
         Stop the background file system watcher started with watch=True. Safe to
         call even if no watcher is running.
         """
-        if self._watch_stop_event is not None:
-            self._watch_stop_event.set()
-        if self._watch_thread is not None:
-            self._watch_thread.join(timeout=5)
-            self._watch_thread = None
+        if self._watcher is not None:
+            self._watcher.stop()
 
     def __enter__(self) -> "PyFileIndex":
         return self
@@ -218,59 +213,6 @@ class PyFileIndex:
                             yield self._get_lst_entry(entry=entry)
         except FileNotFoundError:
             yield from ()
-
-    def _start_watch(self) -> None:
-        """
-        Internal function to start the background file system watcher
-
-        watchfiles.watch() only registers the underlying OS-level watch the
-        first time the generator is advanced, which otherwise happens lazily
-        inside the background thread. To avoid missing changes made right
-        after construction, the generator is advanced once synchronously here
-        before the background thread takes over.
-        """
-        import watchfiles
-
-        self._watch_stop_event = threading.Event()
-        self._watch_generator = watchfiles.watch(
-            self._path,
-            watch_filter=None,
-            stop_event=self._watch_stop_event,
-            rust_timeout=50,
-            yield_on_timeout=True,
-        )
-        if self._watch_generator is not None:
-            next(self._watch_generator)
-        self._watch_thread = threading.Thread(target=self._watch_worker, daemon=True)
-        self._watch_thread.start()
-
-    def _watch_worker(self) -> None:
-        """
-        Internal function run in a background thread to collect file system
-        changes reported by watchfiles into self._pending_changes
-        """
-        if self._watch_generator is None:
-            return
-        try:
-            for changes in self._watch_generator:
-                if len(changes) != 0:
-                    with self._watch_lock:
-                        self._pending_changes.update(changes)
-        except FileNotFoundError:
-            pass
-
-    def _drain_pending_changes(self) -> set:
-        """
-        Internal function to atomically take the file system changes collected
-        by the background watcher since the last call
-
-        Returns:
-            set: set of (watchfiles.Change, path) tuples
-        """
-        with self._watch_lock:
-            changes = self._pending_changes
-            self._pending_changes = set()
-        return changes
 
     def _apply_watch_changes(self, changes: set) -> None:
         """

--- a/src/pyfileindex/watcher.py
+++ b/src/pyfileindex/watcher.py
@@ -1,0 +1,93 @@
+import threading
+from collections.abc import Generator
+from typing import Optional
+
+
+class FileSystemWatcher:
+    """
+    Runs watchfiles in a background thread to collect file system change
+    events for a path, so callers can drain already-collected changes
+    instead of repeatedly rescanning the file system.
+
+    watchfiles is an optional dependency of pyfileindex: importing this
+    module never requires it, only start() does.
+
+    Args:
+        path (str): file system path to watch
+    """
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._lock = threading.Lock()
+        self._pending_changes: set = set()
+        self._stop_event: Optional[threading.Event] = None
+        self._thread: Optional[threading.Thread] = None
+        self._generator: Optional[Generator[set[tuple], None, None]] = None
+
+    @property
+    def thread(self) -> Optional[threading.Thread]:
+        return self._thread
+
+    def start(self) -> None:
+        """
+        Start the background file system watcher.
+
+        watchfiles.watch() only registers the underlying OS-level watch the
+        first time the generator is advanced, which otherwise happens lazily
+        inside the background thread. To avoid missing changes made right
+        after construction, the generator is advanced once synchronously here
+        before the background thread takes over.
+        """
+        import watchfiles
+
+        self._stop_event = threading.Event()
+        self._generator = watchfiles.watch(
+            self._path,
+            watch_filter=None,
+            stop_event=self._stop_event,
+            rust_timeout=50,
+            yield_on_timeout=True,
+        )
+        if self._generator is not None:
+            next(self._generator)
+        self._thread = threading.Thread(target=self._worker, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """
+        Stop the background file system watcher. Safe to call even if no
+        watcher is running.
+        """
+        if self._stop_event is not None:
+            self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    def drain_pending_changes(self) -> set:
+        """
+        Atomically take the file system changes collected since the last
+        call.
+
+        Returns:
+            set: set of (watchfiles.Change, path) tuples
+        """
+        with self._lock:
+            changes = self._pending_changes
+            self._pending_changes = set()
+        return changes
+
+    def _worker(self) -> None:
+        """
+        Internal function run in a background thread to collect file system
+        changes reported by watchfiles into self._pending_changes
+        """
+        if self._generator is None:
+            return
+        try:
+            for changes in self._generator:
+                if len(changes) != 0:
+                    with self._lock:
+                        self._pending_changes.update(changes)
+        except FileNotFoundError:
+            pass

--- a/tests/unit/test_pyfileindex.py
+++ b/tests/unit/test_pyfileindex.py
@@ -388,7 +388,7 @@ class TestJobFileTable(unittest.TestCase):
 
     def test_len(self):
         self.assertEqual(0, len(self.fi_with_filter))
-        self.assertEqual(6, len(self.fi_without_filter))
+        self.assertEqual(8, len(self.fi_without_filter))
         self.assertEqual(0, len(self.fi_debug))
 
     def test_open(self):

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -1,0 +1,85 @@
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+try:
+    import watchfiles  # noqa: F401
+except ImportError:
+    raise unittest.SkipTest("watchfiles is required for these tests")
+
+from pyfileindex.watcher import FileSystemWatcher
+
+
+class TestFileSystemWatcher(unittest.TestCase):
+    """
+    Unit tests for FileSystemWatcher in isolation, without going through
+    PyFileIndex.
+    """
+
+    def test_worker_none_generator(self):
+        watcher = FileSystemWatcher(path=".")
+        watcher._generator = None
+        watcher._worker()
+        self.assertEqual(watcher._pending_changes, set())
+
+    def test_worker_file_not_found(self):
+        def raise_file_not_found():
+            raise FileNotFoundError
+            yield set()
+
+        watcher = FileSystemWatcher(path=".")
+        watcher._generator = raise_file_not_found()
+        watcher._worker()
+        self.assertEqual(watcher._pending_changes, set())
+
+    def test_worker_collects_changes(self):
+        change = (watchfiles.Change.added, "/some/path")
+
+        def generate_changes():
+            yield {change}
+
+        watcher = FileSystemWatcher(path=".")
+        watcher._generator = generate_changes()
+        watcher._worker()
+        self.assertEqual(watcher._pending_changes, {change})
+
+    def test_drain_pending_changes(self):
+        watcher = FileSystemWatcher(path=".")
+        change = (watchfiles.Change.added, "/some/path")
+        watcher._pending_changes = {change}
+        drained = watcher.drain_pending_changes()
+        self.assertEqual(drained, {change})
+        self.assertEqual(watcher._pending_changes, set())
+
+    def test_start_advances_generator_and_starts_thread(self):
+        release = threading.Event()
+
+        def generate_changes():
+            yield {(watchfiles.Change.added, "/some/path")}
+            release.wait()
+
+        with patch("watchfiles.watch", return_value=generate_changes()):
+            watcher = FileSystemWatcher(path=".")
+            watcher.start()
+            try:
+                self.assertIsInstance(watcher.thread, threading.Thread)
+                self.assertTrue(watcher.thread.is_alive())
+            finally:
+                release.set()
+                watcher.stop()
+        self.assertIsNone(watcher.thread)
+
+    def test_stop_without_start_is_noop(self):
+        watcher = FileSystemWatcher(path=".")
+        watcher.stop()
+        self.assertIsNone(watcher.thread)
+
+    def test_stop_sets_stop_event_and_joins_thread(self):
+        watcher = FileSystemWatcher(path=".")
+        watcher._stop_event = MagicMock()
+        thread = MagicMock()
+        watcher._thread = thread
+        watcher.stop()
+        watcher._stop_event.set.assert_called_once()
+        thread.join.assert_called_once_with(timeout=5)
+        self.assertIsNone(watcher.thread)

--- a/tests/unit/test_watchfiles.py
+++ b/tests/unit/test_watchfiles.py
@@ -103,17 +103,17 @@ class TestPyFileIndexWatch(unittest.TestCase):
             fi.close()
 
     def test_watch_close_stops_background_thread(self):
-        thread = self.fi._watch_thread
+        thread = self.fi._watcher.thread
         self.assertTrue(thread.is_alive())
         self.fi.close()
         self.assertFalse(thread.is_alive())
-        self.assertIsNone(self.fi._watch_thread)
+        self.assertIsNone(self.fi._watcher.thread)
         # closing twice should be a no-op, not raise
         self.fi.close()
 
     def test_watch_context_manager(self):
         with PyFileIndex(path=self.path, watch=True) as fi:
-            thread = fi._watch_thread
+            thread = fi._watcher.thread
             self.assertTrue(thread.is_alive())
         self.assertFalse(thread.is_alive())
 
@@ -127,32 +127,17 @@ class TestPyFileIndexWatch(unittest.TestCase):
             fi_sub = self.fi.open(sub_dir)
             try:
                 self.assertTrue(fi_sub._watch_enabled)
-                self.assertIsNotNone(fi_sub._watch_thread)
+                self.assertIsNotNone(fi_sub._watcher.thread)
             finally:
                 fi_sub.close()
         finally:
             os.rmdir(sub_dir)
 
 
-class TestJobFileTableCoverage(unittest.TestCase):
+class TestApplyWatchChanges(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.path = os.path.dirname(os.path.abspath(__file__))
-        cls.fi = PyFileIndex(path=cls.path)
-
-    def test_watch_worker_none_generator(self):
-        self.fi._watch_generator = None
-        self.fi._watch_worker()
-        self.assertEqual(self.fi._pending_changes, set())
-
-    def test_watch_worker_file_not_found(self):
-        def raise_file_not_found():
-            raise FileNotFoundError
-            yield set()
-
-        self.fi._watch_generator = raise_file_not_found()
-        self.fi._watch_worker()
-        self.assertEqual(self.fi._pending_changes, set())
 
     def test_apply_watch_changes_debug_print(self):
         fi = PyFileIndex(path=self.path, debug=True)


### PR DESCRIPTION
## Summary
- Extracts the `watch=True` background-thread logic (added in #293/#294) out of `PyFileIndex` into a dedicated `FileSystemWatcher` class in `src/pyfileindex/watcher.py`, used by `PyFileIndex` via composition.
- Adds `tests/unit/test_watcher.py` with unit tests for `FileSystemWatcher` in isolation (start/stop, worker, draining pending changes), separate from the existing `PyFileIndex(watch=True)` integration tests in `tests/unit/test_watchfiles.py`.
- No behavior change: `PyFileIndex` public API (`watch=True`, `close()`, context manager) is unchanged.

## Test plan
- [x] `python -m unittest discover tests` — all 32 tests pass
- [x] `ruff check src/pyfileindex` — clean