### PR TITLE
Wait for pending watcher changes by default in update()

### DIFF
--- a/src/pyfileindex/pyfileindex.py
+++ b/src/pyfileindex/pyfileindex.py
@@ -102,13 +102,23 @@ class PyFileIndex:
                 watch=self._watch_enabled,
             )
 
-    def update(self) -> None:
+    def update(self, timeout: float = 0.1) -> None:
         """
         Update file index
+
+        Args:
+            timeout (float): when watch=True, a filesystem change made just
+                before calling update() may not have reached the background
+                watcher yet. timeout is the max time in seconds to wait for
+                such a pending change to arrive before applying whatever is
+                available. Ignored when watch=False (optional, default
+                100ms, matching watchfiles' own minimum reporting latency).
         """
         self._check_if_path_exists(path=self._path)
         if self._watcher is not None:
-            self._apply_watch_changes(changes=self._watcher.drain_pending_changes())
+            self._apply_watch_changes(
+                changes=self._watcher.drain_pending_changes(timeout=timeout)
+            )
             return
         df_new, files_changed_lst, path_deleted_lst = self._get_changes_quick()
         if self._debug:

--- a/src/pyfileindex/watcher.py
+++ b/src/pyfileindex/watcher.py
@@ -20,6 +20,7 @@ class FileSystemWatcher:
         self._path = path
         self._lock = threading.Lock()
         self._pending_changes: set = set()
+        self._changes_available = threading.Event()
         self._stop_event: Optional[threading.Event] = None
         self._thread: Optional[threading.Thread] = None
         self._generator: Optional[Generator[set[tuple], None, None]] = None
@@ -64,17 +65,32 @@ class FileSystemWatcher:
             self._thread.join(timeout=5)
             self._thread = None
 
-    def drain_pending_changes(self) -> set:
+    def drain_pending_changes(self, timeout: float = 0.0) -> set:
         """
         Atomically take the file system changes collected since the last
         call.
 
+        A change made on disk is not visible immediately: it takes a small
+        amount of time for the OS to report it and for the background thread
+        to pick it up. If timeout is 0, whatever has arrived so far is
+        returned right away, which may be nothing even though a change just
+        happened. Passing a small timeout instead waits for that change to
+        arrive (or for the timeout to elapse) before returning, without
+        blocking any longer than necessary.
+
+        Args:
+            timeout (float): max time in seconds to wait for a pending
+                change to arrive if none is available yet (optional)
+
         Returns:
             set: set of (watchfiles.Change, path) tuples
         """
+        if timeout > 0:
+            self._changes_available.wait(timeout)
         with self._lock:
             changes = self._pending_changes
             self._pending_changes = set()
+            self._changes_available.clear()
         return changes
 
     def _worker(self) -> None:
@@ -89,5 +105,6 @@ class FileSystemWatcher:
                 if len(changes) != 0:
                     with self._lock:
                         self._pending_changes.update(changes)
+                        self._changes_available.set()
         except FileNotFoundError:
             pass

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -1,4 +1,5 @@
 import threading
+import time
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -47,9 +48,32 @@ class TestFileSystemWatcher(unittest.TestCase):
         watcher = FileSystemWatcher(path=".")
         change = (watchfiles.Change.added, "/some/path")
         watcher._pending_changes = {change}
+        watcher._changes_available.set()
         drained = watcher.drain_pending_changes()
         self.assertEqual(drained, {change})
         self.assertEqual(watcher._pending_changes, set())
+        self.assertFalse(watcher._changes_available.is_set())
+
+    def test_drain_pending_changes_without_timeout_does_not_wait(self):
+        watcher = FileSystemWatcher(path=".")
+        start = time.monotonic()
+        drained = watcher.drain_pending_changes(timeout=0)
+        self.assertEqual(drained, set())
+        self.assertLess(time.monotonic() - start, 1)
+
+    def test_drain_pending_changes_waits_for_late_arriving_change(self):
+        watcher = FileSystemWatcher(path=".")
+        change = (watchfiles.Change.added, "/some/path")
+
+        def add_change_after_delay():
+            time.sleep(0.05)
+            with watcher._lock:
+                watcher._pending_changes.add(change)
+                watcher._changes_available.set()
+
+        threading.Thread(target=add_change_after_delay).start()
+        drained = watcher.drain_pending_changes(timeout=1)
+        self.assertEqual(drained, {change})
 
     def test_start_advances_generator_and_starts_thread(self):
         release = threading.Event()

--- a/tests/unit/test_watchfiles.py
+++ b/tests/unit/test_watchfiles.py
@@ -73,6 +73,26 @@ class TestPyFileIndexWatch(unittest.TestCase):
             update_until(self.fi, lambda: f_name not in self.fi.df.path.values)
         )
 
+    def test_watch_update_default_timeout_catches_immediate_change(self):
+        """
+        A filesystem change made right before update() may not have reached
+        the background watcher yet (e.g. when a notebook runs "Run All" and
+        cells execute back-to-back with no delay between them). update()'s
+        default timeout should wait long enough for it to arrive without the
+        caller needing to add a manual sleep, though OS scheduling jitter
+        means a single call isn't always guaranteed to land within the
+        timeout, so a couple of immediate retries are allowed.
+        """
+        sub_dir = os.path.join(self.path, "immediate")
+        os.makedirs(sub_dir)
+        found = False
+        for _ in range(3):
+            self.fi.update()
+            if sub_dir in self.fi.df.path.values:
+                found = True
+                break
+        self.assertTrue(found)
+
     def test_watch_add_remove_directory(self):
         sub_dir = os.path.join(self.path, "sub")
         nested_file = os.path.join(sub_dir, "nested.txt")


### PR DESCRIPTION
## Summary
- `PyFileIndex.update()` now accepts a `timeout` parameter (default `0.1`s). When `watch=True`, a change made on disk just before `update()` is called may not have reached the background watcher thread yet — this is most visible in Jupyter when running "Run All", where cells execute back-to-back with negligible delay between them, unlike manual cell-by-cell execution which naturally leaves enough time for the watcher to catch up.
- `FileSystemWatcher.drain_pending_changes()` gained a matching `timeout` parameter, implemented with a `threading.Event` so it only waits as long as actually needed (no busy polling).
- The default of `0.1`s was chosen empirically: `watchfiles`' own internal `step` debouncing has a ~50ms minimum reporting latency, so anything below that can never help; 100ms gave consistent results in testing on macOS (FSEvents backend).

## Test plan
- [x] `python -m unittest discover tests` — all 35 tests pass (run 5x to check for flakiness)
- [x] `ruff check src/pyfileindex` — clean
- [x] Reproduced the original bug with a real ipykernel notebook executed via `nbclient` (mirrors "Run All": cells dispatched back-to-back) — confirmed it failed before this change and passes after

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The file index update operation now supports an optional timeout parameter, enabling the system to wait for pending file-system changes during updates when background watching is active.

* **Tests**
  * Expanded test coverage to verify timeout behavior and ensure file-system changes are properly captured when they arrive near update times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->